### PR TITLE
add: Warp terminal gruvbox-dark-soft theme

### DIFF
--- a/set.sh
+++ b/set.sh
@@ -90,6 +90,8 @@ setup_warp_terminal() {
                 safe_remove ~/.warp/*
             fi
             create_symlink "$SCRIPT_DIR/darwin-mac.yaml" ~/.warp/keybindings.yaml "Warp keybindings (macOS)"
+            safe_mkdir ~/.warp/themes
+            create_symlink "$SCRIPT_DIR/warp-terminal/themes/gruvbox-dark-soft.yaml" ~/.warp/themes/gruvbox-dark-soft.yaml "Warp theme (macOS)"
             ;;
         *)
             log "Unsupported OS type: $OSTYPE, skipping Warp terminal setup"

--- a/warp-terminal/themes/gruvbox-dark-soft.yaml
+++ b/warp-terminal/themes/gruvbox-dark-soft.yaml
@@ -1,0 +1,25 @@
+name: Gruvbox Dark Soft
+accent: "#fe8019" # Gruvbox orange
+cursor: "#fe8019" # Gruvbox orange
+background: "#32302f" # dark0_soft
+foreground: "#ebdbb2" # light1 (fg1)
+details: darker
+terminal_colors:
+  normal:
+    black: "#32302f" # dark0_soft (bg0)
+    red: "#cc241d" # neutral_red
+    green: "#98971a" # neutral_green
+    yellow: "#d79921" # neutral_yellow
+    blue: "#458588" # neutral_blue
+    magenta: "#b16286" # neutral_purple
+    cyan: "#689d6a" # neutral_aqua
+    white: "#a89984" # light4 (fg4)
+  bright:
+    black: "#928374" # gray
+    red: "#fb4934" # bright_red
+    green: "#b8bb26" # bright_green
+    yellow: "#fabd2f" # bright_yellow
+    blue: "#83a598" # bright_blue
+    magenta: "#d3869b" # bright_purple
+    cyan: "#8ec07c" # bright_aqua
+    white: "#ebdbb2" # light1 (fg1)


### PR DESCRIPTION
## Summary
- Warp terminal用のGruvbox Dark Softテーマを追加
- set.shにmacOSでのテーマシンボリックリンク設定を追加

## Test plan
- [ ] `set.sh`を実行してテーマがインストールされることを確認
- [ ] Warpターミナルでテーマが選択可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)