### PR TITLE
feat: NeoVimモダンプラグイン導入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ This script:
 - **nvim/**: Complete NeoVim configuration directory
   - `init.lua`: Main NeoVim initialization file
   - `config.vim`: Core Vim configuration
-  - `plugins.vim`: Plugin definitions
+  - `plugins.vim`: Plugin definitions and legacy Lua setup (LSP, completion)
+  - `lua/plugin-config.lua`: Plugin configurations (Neo-tree, Telescope, Gitsigns, Conform, Lualine, Barbar)
+  - `lua/keybindings.lua`: Key mappings (VSCode-like bindings adapted for terminal)
   - `ftdetect/`: File type detection rules
 - **warp-terminal/**: Warp terminal configuration files
 - **darwin-mac.yaml**: macOS-specific keybindings for Warp terminal
@@ -63,6 +65,34 @@ The configuration sets up various development environments:
 - Java: OpenJDK path on macOS
 - Google Cloud SDK integration
 - Cargo (Rust) environment
+
+## System Dependencies (NeoVim)
+
+NeoVim plugins require the following system packages:
+
+### macOS (Homebrew)
+```bash
+brew install ripgrep fd lazygit
+brew tap daipeihust/tap && brew install im-select
+```
+
+### Linux (apt)
+```bash
+sudo apt install ripgrep fd-find
+# lazygit: https://github.com/jesseduffield/lazygit#installation
+```
+
+### Linux (dnf)
+```bash
+sudo dnf install ripgrep fd-find lazygit
+```
+
+| Package | Used by | Purpose |
+|---------|---------|---------|
+| `ripgrep` | Telescope | Live grep / content search |
+| `fd` | Telescope | File finder |
+| `lazygit` | lazygit.nvim | Terminal Git UI |
+| `im-select` | keybindings.lua | IME auto-switch on InsertLeave (macOS only) |
 
 ## Important Notes
 

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -1,0 +1,225 @@
+# Neovim Configuration
+
+VSCodeライクな操作性を持つ、モダンなNeovim設定です。
+
+## 🚀 セットアップ手順
+
+### 1. プラグインのインストール
+
+```bash
+# Neovimを開く
+nvim
+
+# Vimコマンドでプラグインをインストール
+:JetpackSync
+```
+
+### 2. 外部ツールのインストール
+
+#### macOS (Homebrew)
+
+```bash
+# Telescope用のツール
+brew install ripgrep fd
+
+# LazyGit
+brew install lazygit
+
+# IME自動切替 (macOS、日本語入力用)
+brew tap daipeihust/tap && brew install im-select
+
+# フォーマッター (グローバルインストール)
+brew install stylua
+
+# TypeScript/JavaScript フォーマッター (どちらか、または両方)
+npm install -g prettier        # 従来の標準
+npm install -g @biomejs/biome  # 高速・モダン (推奨)
+
+# Python用
+pip install black
+
+# Go用 (goが既にインストールされている場合)
+go install golang.org/x/tools/cmd/gofmt@latest
+```
+
+### 3. LSPサーバーのインストール
+
+Neovimを開いて、以下のコマンドを実行:
+
+```vim
+:Mason
+```
+
+Masonが開いたら、以下をインストール:
+- `typescript-language-server` (TypeScript/JavaScript)
+- `lua-language-server` (Lua)
+- `gopls` (Go)
+- `intelephense` (PHP)
+
+## 📦 インストールされるプラグイン
+
+### ファイル管理
+- **neo-tree.nvim** - ファイルエクスプローラ
+- **telescope.nvim** - ファジーファインダー (ファイル検索、grep等)
+- **barbar.nvim** - バッファ/タブライン
+
+### Git統合
+- **gitsigns.nvim** - Git変更表示
+- **vim-fugitive** - Git操作
+- **lazygit.nvim** - LazyGitインターフェース
+
+### コード編集
+- **conform.nvim** - 自動フォーマッター (保存時実行)
+- **editorconfig-vim** - EditorConfig対応
+
+### LSP & 補完
+- **mason.nvim** - LSPインストーラー
+- **nvim-lspconfig** - LSP設定
+- **nvim-cmp** - 自動補完
+
+### UI
+- **lualine.nvim** - ステータスライン
+- **gruvbox** - カラーテーマ
+
+## ⌨️ キーバインド
+
+### バッファ/タブ操作
+| キー | 動作 |
+|------|------|
+| `Shift+L` | 次のバッファ |
+| `Shift+H` | 前のバッファ |
+| `Cmd/Ctrl+W` | バッファを閉じる |
+| `Cmd/Alt+1~9` | バッファ1~9に移動 |
+
+### ファイル操作
+| キー | 動作 |
+|------|------|
+| `Cmd/Ctrl+P` | ファイル検索 |
+| `Cmd/Ctrl+Shift+F` | プロジェクト内検索 |
+| `Cmd/Ctrl+B` | ファイルエクスプローラ表示/非表示 (閉じると元のファイルに戻る) |
+| `Cmd/Ctrl+Shift+E` | ファイルエクスプローラにフォーカス |
+| `Ctrl+L` | エクスプローラから元のファイルに戻る (右ウィンドウへ移動) |
+| `Cmd/Ctrl+T` | 新規ファイル |
+| `Cmd/Ctrl+S` | 保存 |
+
+### Git操作
+| キー | 動作 |
+|------|------|
+| `Cmd/Ctrl+Shift+G` | LazyGitを開く |
+| `]c` / `[c` | 次/前の変更箇所に移動 |
+| `<leader>gb` | Git blameの表示切替 |
+
+### LSP操作
+| キー | 動作 |
+|------|------|
+| `gd` | 定義にジャンプ |
+| `gr` | 参照を表示 |
+| `K` | ホバー情報表示 |
+| `<F2>` | シンボル名変更 |
+| `<leader>ca` | コードアクション |
+| `[d` / `]d` | 次/前の診断に移動 |
+
+### ナビゲーション
+| キー | 動作 |
+|------|------|
+| `Ctrl+-` | 戻る |
+| `Ctrl+=` | 進む |
+
+### フォーマット
+| キー | 動作 |
+|------|------|
+| `Cmd+Shift+I` | コードフォーマット |
+| `<leader>f` | コードフォーマット |
+
+### ターミナル
+| キー | 動作 |
+|------|------|
+| `Cmd+Shift+2` | ターミナルを開く |
+| `Ctrl+\`` | ターミナルを開く |
+| `Esc` (ターミナル内) | ノーマルモードに戻る |
+
+> `<leader>`キーはデフォルトで`Space`に設定されています
+
+## 🔧 設定ファイル構成
+
+```
+nvim/
+├── init.lua              # エントリーポイント
+├── config.vim            # 基本設定
+├── plugins.vim           # プラグイン定義
+└── lua/
+    ├── plugin-config.lua # プラグイン設定
+    └── keybindings.lua   # キーバインド設定
+```
+
+## 📝 カスタマイズ
+
+### フォーマッターの自動選択
+
+TypeScript/JavaScriptのフォーマッターは**プロジェクトに応じて自動選択**されます:
+
+1. **Biome** がプロジェクトにあれば → Biomeを使用
+2. なければ **Prettier** を使用 → Prettierを使用
+3. どちらもなければ → LSPフォーマッターを使用
+
+#### プロジェクトごとの設定例
+
+```bash
+# Biomeを使うプロジェクト
+npm install --save-dev @biomejs/biome
+# または
+pnpm add -D @biomejs/biome
+
+# Prettierを使うプロジェクト
+npm install --save-dev prettier
+# または
+pnpm add -D prettier
+```
+
+グローバルにインストールしておけば、プロジェクトに設定がない場合も自動フォーマットされます。
+
+### フォーマッターの設定変更
+
+`lua/plugin-config.lua`の`conform.setup`セクションで変更:
+
+```lua
+require("conform").setup({
+  formatters_by_ft = {
+    javascript = { "biome", "prettier", stop_after_first = true },
+    typescript = { "biome", "prettier", stop_after_first = true },
+    -- 言語を追加...
+  },
+})
+```
+
+### キーバインドの変更
+
+`lua/keybindings.lua`で任意のキーバインドを追加・変更できます。
+
+## 🐛 トラブルシューティング
+
+### プラグインが読み込まれない
+
+```vim
+:JetpackSync
+:checkhealth
+```
+
+### LSPが動作しない
+
+```vim
+:LspInfo
+:Mason
+```
+
+### フォーマッターが動作しない
+
+1. フォーマッターがインストールされているか確認
+2. `:ConformInfo`でステータス確認
+
+## 📚 参考リンク
+
+- [Neovim Documentation](https://neovim.io/doc/)
+- [Telescope](https://github.com/nvim-telescope/telescope.nvim)
+- [Neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
+- [Conform.nvim](https://github.com/stevearc/conform.nvim)

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,2 +1,60 @@
+-- Load Vim configuration
 vim.cmd("runtime! ./config.vim")
+
+-- Check if vim-jetpack is installed
+local jetpack_path = vim.fn.stdpath('data') .. '/site/pack/jetpack/opt/vim-jetpack'
+if vim.fn.isdirectory(jetpack_path) == 0 then
+  vim.api.nvim_create_autocmd('VimEnter', {
+    callback = function()
+      vim.notify(
+        'vim-jetpack がインストールされていません\n\n' ..
+        'インストール:\n' ..
+        '  git clone https://github.com/tani/vim-jetpack ' .. jetpack_path,
+        vim.log.levels.ERROR
+      )
+    end,
+  })
+  require('keybindings')
+  return
+end
+
 vim.cmd("runtime! ./plugins.vim")
+
+-- Check if plugins are installed, show message if not
+local missing = {}
+local check_plugins = {
+  { mod = 'neo-tree',  name = 'neo-tree.nvim' },
+  { mod = 'telescope', name = 'telescope.nvim' },
+  { mod = 'gitsigns',  name = 'gitsigns.nvim' },
+  { mod = 'conform',   name = 'conform.nvim' },
+  { mod = 'lualine',   name = 'lualine.nvim' },
+  { mod = 'barbar',    name = 'barbar.nvim' },
+}
+
+for _, plugin in ipairs(check_plugins) do
+  local ok, _ = pcall(require, plugin.mod)
+  if not ok then
+    table.insert(missing, plugin.name)
+  end
+end
+
+if #missing > 0 then
+  vim.api.nvim_create_autocmd('VimEnter', {
+    callback = function()
+      vim.notify(
+        '未インストールのプラグインがあります:\n  ' ..
+        table.concat(missing, '\n  ') ..
+        '\n\n:JetpackSync を実行してください',
+        vim.log.levels.WARN
+      )
+    end,
+  })
+end
+
+-- Load Lua configurations (pcall to avoid errors if plugins missing)
+local ok, err = pcall(require, 'plugin-config')
+if not ok then
+  vim.notify('plugin-config の読み込みに失敗: ' .. err, vim.log.levels.WARN)
+end
+
+require('keybindings')

--- a/nvim/lua/keybindings.lua
+++ b/nvim/lua/keybindings.lua
@@ -1,0 +1,204 @@
+-- ============================================
+-- Keybindings Configuration
+-- VSCode-like keybindings for Neovim
+-- ============================================
+
+local map = vim.keymap.set
+local opts = { noremap = true, silent = true }
+
+-- ============================================
+-- IME: InsertモードからNormalモードに戻る時にIMEをオフにする
+-- ============================================
+local ime_off
+if vim.fn.executable('im-select') == 1 then
+  ime_off = function()
+    vim.fn.system('im-select com.apple.keylayout.ABC')
+  end
+
+  -- Insertモードから抜けた時
+  vim.api.nvim_create_autocmd('InsertLeave', { callback = ime_off })
+else
+  ime_off = function() end
+end
+
+-- ============================================
+-- Leader key
+-- ============================================
+vim.g.mapleader = ' '
+
+-- ============================================
+-- Buffer Navigation (VSCode Tab-like)
+-- ============================================
+-- Shift+L / Shift+H: Next/Previous buffer (LazyVim style)
+map('n', '<S-l>', ':BufferNext<CR>', opts)
+map('n', '<S-h>', ':BufferPrevious<CR>', opts)
+
+-- Close buffer
+map('n', '<D-w>', ':BufferClose<CR>', opts)
+map('n', '<C-w>', ':BufferClose<CR>', opts)
+
+-- Move buffer position
+map('n', '<A-<>', ':BufferMovePrevious<CR>', opts)
+map('n', '<A->>', ':BufferMoveNext<CR>', opts)
+
+-- Go to buffer in position (like VSCode Cmd+1, Cmd+2, ...)
+for i = 1, 9 do
+  map('n', '<D-' .. i .. '>', ':BufferGoto ' .. i .. '<CR>', opts)
+  map('n', '<A-' .. i .. '>', ':BufferGoto ' .. i .. '<CR>', opts)
+end
+
+-- Pin/unpin buffer
+map('n', '<A-p>', ':BufferPin<CR>', opts)
+
+-- ============================================
+-- File Explorer (Neo-tree)
+-- ============================================
+-- Cmd+B or Ctrl+B: Toggle file explorer (like VSCode)
+map('n', '<D-b>', function() ime_off(); vim.cmd('Neotree toggle') end, opts)
+map('n', '<C-b>', function() ime_off(); vim.cmd('Neotree toggle') end, opts)
+
+-- Cmd/Ctrl+Shift+E: Focus file explorer (open if closed)
+map('n', '<D-S-e>', function() ime_off(); vim.cmd('Neotree focus') end, opts)
+map('n', '<C-S-e>', function() ime_off(); vim.cmd('Neotree focus') end, opts)
+
+-- Reveal current file in explorer
+map('n', '<leader>e', ':Neotree reveal<CR>', opts)
+
+-- ============================================
+-- Fuzzy Finder (Telescope)
+-- ============================================
+-- Cmd+P: Find files (like VSCode)
+map('n', '<D-p>', ':Telescope find_files<CR>', opts)
+map('n', '<C-p>', ':Telescope find_files<CR>', opts)
+
+-- Cmd+Shift+F: Global search (like VSCode)
+map('n', '<D-S-f>', ':Telescope live_grep<CR>', opts)
+map('n', '<C-S-f>', ':Telescope live_grep<CR>', opts)
+
+-- Ctrl+Tab (alternative): Show buffer list
+map('n', '<leader>b', ':Telescope buffers<CR>', opts)
+
+-- Recent files
+map('n', '<leader>r', ':Telescope oldfiles<CR>', opts)
+
+-- Git files
+map('n', '<leader>gf', ':Telescope git_files<CR>', opts)
+
+-- Symbols
+map('n', '<D-S-o>', ':Telescope lsp_document_symbols<CR>', opts)
+map('n', '<C-S-o>', ':Telescope lsp_document_symbols<CR>', opts)
+
+-- ============================================
+-- Git Integration
+-- ============================================
+-- Cmd+Shift+G: Open LazyGit (like VSCode SCM view)
+map('n', '<D-S-g>', ':LazyGit<CR>', opts)
+map('n', '<C-S-g>', ':LazyGit<CR>', opts)
+
+-- Git hunk navigation
+map('n', ']c', ':Gitsigns next_hunk<CR>', opts)
+map('n', '[c', ':Gitsigns prev_hunk<CR>', opts)
+
+-- Git blame
+map('n', '<leader>gb', ':Gitsigns toggle_current_line_blame<CR>', opts)
+
+-- Git status (Fugitive)
+map('n', '<leader>gs', ':Git<CR>', opts)
+
+-- ============================================
+-- LSP Navigation
+-- ============================================
+-- Go to definition (Cmd+Click in VSCode)
+map('n', 'gd', vim.lsp.buf.definition, opts)
+map('n', '<D-]>', vim.lsp.buf.definition, opts)
+
+-- Go back/forward (like VSCode)
+map('n', '<C-->', '<C-o>', opts)  -- Back
+map('n', '<C-=>', '<C-i>', opts)  -- Forward
+map('n', '<C-S-->', '<C-i>', opts)
+map('n', '<C-S-=>', '<C-i>', opts)
+
+-- Hover documentation
+map('n', 'K', vim.lsp.buf.hover, opts)
+map('n', '<D-k>', vim.lsp.buf.hover, opts)
+
+-- Show references
+map('n', 'gr', vim.lsp.buf.references, opts)
+map('n', '<D-S-r>', vim.lsp.buf.references, opts)
+
+-- Rename symbol
+map('n', '<F2>', vim.lsp.buf.rename, opts)
+map('n', '<leader>rn', vim.lsp.buf.rename, opts)
+
+-- Code actions
+map('n', '<leader>ca', vim.lsp.buf.code_action, opts)
+map('n', '<D-.>', vim.lsp.buf.code_action, opts)
+
+-- Diagnostics
+map('n', '<leader>d', vim.diagnostic.open_float, opts)
+map('n', '[d', vim.diagnostic.goto_prev, opts)
+map('n', ']d', vim.diagnostic.goto_next, opts)
+
+-- ============================================
+-- Formatting
+-- ============================================
+-- Cmd+Shift+I or Alt+Shift+F: Format document (like VSCode)
+map('n', '<D-S-i>', function() require("conform").format({ async = true, lsp_fallback = true }) end, opts)
+map('n', '<A-S-f>', function() require("conform").format({ async = true, lsp_fallback = true }) end, opts)
+map('n', '<leader>f', function() require("conform").format({ async = true, lsp_fallback = true }) end, opts)
+
+-- ============================================
+-- Terminal
+-- ============================================
+-- Cmd+Shift+2: Toggle terminal (like VSCode Cmd+J)
+map('n', '<D-S-2>', ':terminal<CR>', opts)
+map('n', '<C-`>', ':terminal<CR>', opts)
+
+-- Terminal mode escape
+map('t', '<Esc>', '<C-\\><C-n>', opts)
+
+-- ============================================
+-- File Operations
+-- ============================================
+-- Cmd+T or Ctrl+T: New file (like VSCode)
+map('n', '<D-t>', ':enew<CR>', opts)
+map('n', '<C-t>', ':enew<CR>', opts)
+
+-- Cmd+S: Save (like VSCode)
+map('n', '<D-s>', ':w<CR>', opts)
+map('n', '<C-s>', ':w<CR>', opts)
+
+-- Cmd+Shift+C: Copy relative file path (like VSCode)
+map('n', '<D-S-c>', ':let @+ = expand("%")<CR>', opts)
+map('n', '<C-S-c>', ':let @+ = expand("%")<CR>', opts)
+
+-- ============================================
+-- Window Management
+-- ============================================
+-- Split windows
+map('n', '<leader>sv', ':vsplit<CR>', opts)
+map('n', '<leader>sh', ':split<CR>', opts)
+
+-- Navigate between windows
+map('n', '<C-h>', '<C-w>h', opts)
+map('n', '<C-j>', '<C-w>j', opts)
+map('n', '<C-k>', '<C-w>k', opts)
+map('n', '<C-l>', '<C-w>l', opts)
+
+-- ============================================
+-- Quick Actions
+-- ============================================
+-- Clear search highlight
+map('n', '<Esc>', ':noh<CR>', opts)
+
+-- Select all
+map('n', '<D-a>', 'ggVG', opts)
+map('n', '<C-a>', 'ggVG', opts)
+
+-- Comment toggle (Neovim 0.10+ built-in gc/gcc)
+map('n', '<D-/>', 'gcc', { remap = true })
+map('n', '<C-/>', 'gcc', { remap = true })
+map('v', '<D-/>', 'gc', { remap = true })
+map('v', '<C-/>', 'gc', { remap = true })
+
+print("Keybindings loaded successfully")

--- a/nvim/lua/plugin-config.lua
+++ b/nvim/lua/plugin-config.lua
@@ -1,0 +1,195 @@
+-- ============================================
+-- Neo-tree (File Explorer)
+-- ============================================
+require("neo-tree").setup({
+  close_if_last_window = true,
+  popup_border_style = "rounded",
+  enable_git_status = true,
+  enable_diagnostics = true,
+  default_component_configs = {
+    indent = {
+      indent_size = 2,
+      padding = 1,
+    },
+    icon = {
+      folder_closed = "",
+      folder_open = "",
+      folder_empty = "󰜌",
+      default = "*",
+    },
+  },
+  window = {
+    position = "left",
+    width = 30,
+  },
+  filesystem = {
+    filtered_items = {
+      hide_dotfiles = false,
+      hide_gitignored = false,
+    },
+    follow_current_file = {
+      enabled = true,
+    },
+  },
+})
+
+-- ============================================
+-- Telescope (Fuzzy Finder)
+-- ============================================
+require('telescope').setup({
+  defaults = {
+    file_ignore_patterns = { "node_modules", ".git/" },
+    layout_strategy = 'horizontal',
+    layout_config = {
+      horizontal = {
+        preview_width = 0.5,
+      },
+    },
+  },
+  extensions = {
+    fzf = {
+      fuzzy = true,
+      override_generic_sorter = true,
+      override_file_sorter = true,
+      case_mode = "smart_case",
+    }
+  }
+})
+-- Load fzf native extension
+pcall(require('telescope').load_extension, 'fzf')
+
+-- ============================================
+-- Gitsigns (Git Integration)
+-- ============================================
+require('gitsigns').setup({
+  signs = {
+    add          = { text = '│' },
+    change       = { text = '│' },
+    delete       = { text = '_' },
+    topdelete    = { text = '‾' },
+    changedelete = { text = '~' },
+    untracked    = { text = '┆' },
+  },
+  current_line_blame = false,
+  current_line_blame_opts = {
+    virt_text = true,
+    virt_text_pos = 'eol',
+    delay = 1000,
+  },
+  on_attach = function(bufnr)
+    local gs = package.loaded.gitsigns
+
+    local function map(mode, l, r, opts)
+      opts = opts or {}
+      opts.buffer = bufnr
+      vim.keymap.set(mode, l, r, opts)
+    end
+
+    -- Navigation
+    map('n', ']c', function()
+      if vim.wo.diff then return ']c' end
+      vim.schedule(function() gs.next_hunk() end)
+      return '<Ignore>'
+    end, {expr=true})
+
+    map('n', '[c', function()
+      if vim.wo.diff then return '[c' end
+      vim.schedule(function() gs.prev_hunk() end)
+      return '<Ignore>'
+    end, {expr=true})
+
+    -- Actions
+    map('n', '<leader>hs', gs.stage_hunk)
+    map('n', '<leader>hr', gs.reset_hunk)
+    map('n', '<leader>hu', gs.undo_stage_hunk)
+    map('n', '<leader>hp', gs.preview_hunk)
+    map('n', '<leader>hb', function() gs.blame_line{full=true} end)
+    map('n', '<leader>tb', gs.toggle_current_line_blame)
+  end
+})
+
+-- ============================================
+-- Conform (Auto Formatter)
+-- ============================================
+require("conform").setup({
+  formatters_by_ft = {
+    -- TypeScript/JavaScript: プロジェクトに応じて自動選択
+    -- Biome → Prettier の順で試行 (最初に見つかったものを使用)
+    javascript = { "biome", "prettier", stop_after_first = true },
+    typescript = { "biome", "prettier", stop_after_first = true },
+    javascriptreact = { "biome", "prettier", stop_after_first = true },
+    typescriptreact = { "biome", "prettier", stop_after_first = true },
+    json = { "biome", "prettier", stop_after_first = true },
+
+    -- その他の言語
+    css = { "prettier" },
+    html = { "prettier" },
+    yaml = { "prettier" },
+    markdown = { "prettier" },
+    lua = { "stylua" },
+    go = { "gofmt" },
+    python = { "black" },
+  },
+  format_on_save = {
+    timeout_ms = 500,
+    lsp_fallback = true,
+  },
+})
+
+-- ============================================
+-- Lualine (Status Line)
+-- ============================================
+require('lualine').setup({
+  options = {
+    theme = 'gruvbox',
+    component_separators = { left = '', right = ''},
+    section_separators = { left = '', right = ''},
+  },
+  sections = {
+    lualine_a = {'mode'},
+    lualine_b = {'branch', 'diff', 'diagnostics'},
+    lualine_c = {'filename'},
+    lualine_x = {'encoding', 'fileformat', 'filetype'},
+    lualine_y = {'progress'},
+    lualine_z = {'location'}
+  },
+})
+
+-- ============================================
+-- Barbar (Buffer/Tab Line)
+-- ============================================
+require('barbar').setup({
+  animation = true,
+  auto_hide = false,
+  tabpages = true,
+  clickable = true,
+  icons = {
+    buffer_index = false,
+    buffer_number = false,
+    button = '',
+    diagnostics = {
+      [vim.diagnostic.severity.ERROR] = {enabled = true, icon = 'E'},
+      [vim.diagnostic.severity.WARN] = {enabled = true, icon = 'W'},
+      [vim.diagnostic.severity.INFO] = {enabled = false},
+      [vim.diagnostic.severity.HINT] = {enabled = false},
+    },
+    gitsigns = {
+      added = {enabled = true, icon = '+'},
+      changed = {enabled = true, icon = '~'},
+      deleted = {enabled = true, icon = '-'},
+    },
+    filetype = {
+      enabled = true,
+    },
+    separator = {left = '▎', right = ''},
+    modified = {button = '●'},
+    pinned = {button = '', filename = true},
+    preset = 'default',
+    alternate = {filetype = {enabled = false}},
+    current = {buffer_index = false},
+    inactive = {button = '×'},
+    visible = {modified = {buffer_number = false}},
+  },
+})
+
+print("Plugin configurations loaded successfully")

--- a/nvim/plugins.vim
+++ b/nvim/plugins.vim
@@ -3,20 +3,59 @@ call jetpack#begin()
 " bootstrap
 Jetpack 'tani/vim-jetpack', {'opt': 1}
 
-" On-demand loading
+" ============================================
+" File Explorer & Navigation
+" ============================================
+" File explorer
+Jetpack 'nvim-neo-tree/neo-tree.nvim'
+Jetpack 'nvim-lua/plenary.nvim'
+Jetpack 'nvim-tree/nvim-web-devicons'
+Jetpack 'MunifTanjim/nui.nvim'
+
+" Fuzzy finder (keeping fzf for compatibility)
 Jetpack 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 Jetpack 'junegunn/fzf.vim'
+Jetpack 'nvim-telescope/telescope.nvim'
+Jetpack 'nvim-telescope/telescope-fzf-native.nvim', {'do': 'make'}
 
-" color  theme
+" Buffer/Tab line
+Jetpack 'romgrk/barbar.nvim'
+
+" ============================================
+" Git Integration
+" ============================================
+Jetpack 'lewis6991/gitsigns.nvim'
+Jetpack 'tpope/vim-fugitive'
+Jetpack 'kdheepak/lazygit.nvim'
+
+" ============================================
+" UI & Appearance
+" ============================================
+" Color theme
 Jetpack 'morhetz/gruvbox'
 
-" editorconfig plugin
+" Status line
+Jetpack 'nvim-lualine/lualine.nvim'
+
+" ============================================
+" Code Formatting & Editing
+" ============================================
+" Auto formatter
+Jetpack 'stevearc/conform.nvim'
+
+" Editorconfig plugin
 Jetpack 'editorconfig/editorconfig-vim'
 
+" ============================================
+" Language Support
+" ============================================
 " jsx tsx syntax highlight
 Jetpack 'leafgarland/typescript-vim'
 Jetpack 'peitalin/vim-jsx-typescript'
 
+" ============================================
+" LSP & Completion
+" ============================================
 " nvim lsp
 Jetpack 'williamboman/mason.nvim'
 Jetpack 'williamboman/mason-lspconfig.nvim'
@@ -94,20 +133,30 @@ lua <<EOF
     })
   })
 
-  -- Set up lspconfig.
+  -- Set up LSP (vim.lsp.config API for nvim 0.11+)
   local capabilities = require('cmp_nvim_lsp').default_capabilities()
-  require('lspconfig')['denols'].setup {
-    capabilities = capabilities
-  }
 
-  require('lspconfig')['ts_ls'].setup {
+  vim.lsp.config('denols', {
     capabilities = capabilities,
-    root_dir = require('lspconfig').util.root_pattern("package.json"),
-    single_file_support = false,
-  }
+    root_markers = { 'deno.json', 'deno.jsonc' },
+  })
 
-  require('lspconfig')['gopls'].setup{}
+  vim.lsp.config('ts_ls', {
+    capabilities = capabilities,
+    root_markers = { 'package.json' },
+    workspace = {
+      single_file_support = false,
+    },
+  })
 
-  require('lspconfig')['intelephense'].setup{}
+  vim.lsp.config('gopls', {
+    capabilities = capabilities,
+  })
+
+  vim.lsp.config('intelephense', {
+    capabilities = capabilities,
+  })
+
+  vim.lsp.enable({ 'denols', 'ts_ls', 'gopls', 'intelephense' })
 
 EOF


### PR DESCRIPTION
## Summary
- Neo-tree, Telescope, Gitsigns, Fugitive, LazyGit, Conform, Barbar, Lualine を追加
- VSCodeライクなキーバインドを設定 (Shift+H/L でバッファ切替、Ctrl+B でエクスプローラ等)
- LSP設定を `vim.lsp.config` API (nvim 0.11+) に移行
- Conform によるプロジェクトごとの自動フォーマット (Biome/Prettier 自動選択)
- IME自動切替 (im-select) 対応
- プラグイン未インストール時の警告メッセージ表示
- CLAUDE.md にシステム依存パッケージを追記

## Test plan
- [ ] `:JetpackSync` で全プラグインがインストールされること
- [ ] `Ctrl+B` でファイルエクスプローラが開閉すること
- [ ] `Shift+H` / `Shift+L` でバッファ切替できること
- [ ] `:Telescope find_files` でファイル検索できること
- [ ] `:LazyGit` でLazyGitが起動すること
- [ ] TypeScriptファイル保存時にフォーマッターが実行されること
- [ ] IME自動切替が動作すること (macOS)